### PR TITLE
bg: ensure init is complete before returning

### DIFF
--- a/bg/connect.go
+++ b/bg/connect.go
@@ -51,8 +51,10 @@ func Connect(client Client, options ...Option) (StopFunc, error) {
 	ctx, cancel := context.WithCancel(opt.ctx)
 	g, ctx := errgroup.WithContext(ctx)
 
+	initDone := make(chan struct{})
 	g.Go(func() error {
 		return client.Run(ctx, func(ctx context.Context) error {
+			close(initDone)
 			<-ctx.Done()
 			if errors.Is(ctx.Err(), context.Canceled) {
 				return nil
@@ -60,6 +62,7 @@ func Connect(client Client, options ...Option) (StopFunc, error) {
 			return ctx.Err()
 		})
 	})
+	<-initDone
 
 	return func() error {
 		cancel()

--- a/bg/connect.go
+++ b/bg/connect.go
@@ -1,6 +1,4 @@
 // Package bg implements wrapper for running client in background.
-//
-// TODO: Once https://github.com/gotd/contrib/pull/216 is merged can be removed.
 package bg
 
 import (


### PR DESCRIPTION
I encountered an issue, where i started Auth immediately after calling Connect, and it seems that the Auth kicked in before the client.Run has finished initialisation.

The code that revealed the problem:
```go
// for context
type Client {
	cl *telegram.Client
	auth auth.UserAuthenticator
	sendcodeOpts auth.SendCodeOptions
}

func (c *Client) Start(ctx context.Context) error {
// <...>

	stop, err := bg.Connect(c.cl)
	if err != nil {
		return err
	}

	// time.Sleep(500*time.Millisecond) // works around the issue

	flow := auth.NewFlow(c.auth, c.sendcodeOpts)
	if err := c.cl.Auth().IfNecessary(ctx, flow); err != nil {
		return err
	}
	log.Println("auth success")

}
```

To confirm this theory, I added a time.Sleep(500*time.Millisecond) after Connect, and before Auth (as shown on the commented line above)

Introducing the synchronisation in Connect fixes the described problem.