### PR TITLE
fix: resolve golangci-lint issues and 386 test failure

### DIFF
--- a/auth/dialog/dialog.go
+++ b/auth/dialog/dialog.go
@@ -44,7 +44,7 @@ func (d Dialog) Phone(ctx context.Context) (string, error) {
 		"",
 	)
 	if err != nil {
-		return "", errors.Errorf("show dialog: %w", err)
+		return "", errors.Wrap(err, "show dialog")
 	}
 	if !ok {
 		return "", errDialogClosed
@@ -60,7 +60,7 @@ func (d Dialog) Password(ctx context.Context) (string, error) {
 		d.printer.Sprintf(localization.PasswordDialogPrompt),
 	)
 	if err != nil {
-		return "", errors.Errorf("show dialog: %w", err)
+		return "", errors.Wrap(err, "show dialog")
 	}
 	if !ok {
 		return "", errDialogClosed
@@ -77,7 +77,7 @@ func (d Dialog) AcceptTermsOfService(ctx context.Context, tos tg.HelpTermsOfServ
 		false,
 	)
 	if err != nil {
-		return errors.Errorf("show dialog: %w", err)
+		return errors.Wrap(err, "show dialog")
 	}
 	if !ok {
 		return errDialogClosed
@@ -94,7 +94,7 @@ func (d Dialog) SignUp(ctx context.Context) (tgauth.UserInfo, error) {
 		"",
 	)
 	if err != nil {
-		return tgauth.UserInfo{}, errors.Errorf("show dialog: %w", err)
+		return tgauth.UserInfo{}, errors.Wrap(err, "show dialog")
 	}
 	if !ok {
 		return tgauth.UserInfo{}, errDialogClosed
@@ -106,7 +106,7 @@ func (d Dialog) SignUp(ctx context.Context) (tgauth.UserInfo, error) {
 		"",
 	)
 	if err != nil {
-		return tgauth.UserInfo{}, errors.Errorf("show dialog: %w", err)
+		return tgauth.UserInfo{}, errors.Wrap(err, "show dialog")
 	}
 	if !ok {
 		return tgauth.UserInfo{}, errDialogClosed
@@ -125,7 +125,7 @@ func (d Dialog) Code(ctx context.Context, sentCode *tg.AuthSentCode) (string, er
 	for {
 		code, ok, err := dlgs.Entry(title, prompt, "")
 		if err != nil {
-			return "", errors.Errorf("show dialog: %w", err)
+			return "", errors.Wrap(err, "show dialog")
 		}
 		if !ok {
 			return "", errDialogClosed
@@ -143,7 +143,7 @@ func (d Dialog) Code(ctx context.Context, sentCode *tg.AuthSentCode) (string, er
 			if len(code) != length {
 				_, err := dlgs.Error(title, d.printer.Sprintf(localization.CodeInvalidLength, length)+"\n")
 				if err != nil {
-					return "", errors.Errorf("write error message: %w", err)
+					return "", errors.Wrap(err, "write error message")
 				}
 				continue
 			}

--- a/auth/terminal/code.go
+++ b/auth/terminal/code.go
@@ -87,7 +87,7 @@ func (t *Terminal) Code(ctx context.Context, sentCode *tg.AuthSentCode) (string,
 			if len(code) != length {
 				_, err := io.WriteString(t.Terminal, t.printer.Sprintf(localization.CodeInvalidLength, length)+"\n")
 				if err != nil {
-					return "", errors.Errorf("write error message: %w", err)
+					return "", errors.Wrap(err, "write error message")
 				}
 				continue
 			}
@@ -104,12 +104,12 @@ func (t *Terminal) Code(ctx context.Context, sentCode *tg.AuthSentCode) (string,
 func (t *Terminal) SignUp(ctx context.Context) (u tgauth.UserInfo, err error) {
 	u.FirstName, err = t.read(t.printer.Sprintf(localization.FirstNameDialogPrompt) + ":")
 	if err != nil {
-		return u, errors.Errorf("read first name: %w", err)
+		return u, errors.Wrap(err, "read first name")
 	}
 
 	u.LastName, err = t.read(t.printer.Sprintf(localization.SecondNameDialogPrompt) + ":")
 	if err != nil {
-		return u, errors.Errorf("read first name: %w", err)
+		return u, errors.Wrap(err, "read first name")
 	}
 
 	return u, nil
@@ -120,7 +120,7 @@ func (t *Terminal) SignUp(ctx context.Context) (u tgauth.UserInfo, err error) {
 func (t *Terminal) AcceptTermsOfService(ctx context.Context, tos tg.HelpTermsOfService) error {
 	_, err := io.WriteString(t.Terminal, t.printer.Sprintf(localization.TOSDialogTitle)+"\n\n"+tos.Text)
 	if err != nil {
-		return errors.Errorf("write terms of service: %w", err)
+		return errors.Wrap(err, "write terms of service")
 	}
 
 	t.SetPrompt(t.printer.Sprintf(localization.TOSDialogPrompt) + "(Y/N):")
@@ -129,7 +129,7 @@ func (t *Terminal) AcceptTermsOfService(ctx context.Context, tos tg.HelpTermsOfS
 loop:
 	y, err := t.ReadLine()
 	if err != nil {
-		return errors.Errorf("read answer: %w", err)
+		return errors.Wrap(err, "read answer")
 	}
 	switch strings.ToLower(y) {
 	case "y", "yes":

--- a/bbolt/auth_example_test.go
+++ b/bbolt/auth_example_test.go
@@ -20,7 +20,7 @@ import (
 func bboltAuth(ctx context.Context) error {
 	db, err := bboltdb.Open("bbolt.db", 0666, &bboltdb.Options{}) // nolint:gocritic
 	if err != nil {
-		return errors.Errorf("create bbolt storage: %w", err)
+		return errors.Wrap(err, "create bbolt storage")
 	}
 	cred := bbolt.NewCredentials(db, []byte("bucket")).
 		WithPhoneKey("phone").
@@ -28,7 +28,7 @@ func bboltAuth(ctx context.Context) error {
 
 	client, err := telegram.ClientFromEnvironment(telegram.Options{})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/bbolt/client.go
+++ b/bbolt/client.go
@@ -18,11 +18,11 @@ func (p bboltStorage) Set(ctx context.Context, k, v string) (rerr error) {
 	return p.db.Batch(func(tx *bbolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists(p.bucket)
 		if err != nil {
-			return errors.Errorf("create bucket: %w", err)
+			return errors.Wrap(err, "create bucket")
 		}
 
 		if err := bucket.Put([]byte(k), []byte(v)); err != nil {
-			return errors.Errorf("put: %w", err)
+			return errors.Wrap(err, "put")
 		}
 		return nil
 	})

--- a/bbolt/peer_storage.go
+++ b/bbolt/peer_storage.go
@@ -72,7 +72,7 @@ func (p *bboltIterator) Value() storage.Peer {
 func (s PeerStorage) Iterate(ctx context.Context) (storage.PeerIterator, error) {
 	tx, err := s.bbolt.Begin(false)
 	if err != nil {
-		return nil, errors.Errorf("create tx: %w", err)
+		return nil, errors.Wrap(err, "create tx")
 	}
 
 	bucket := tx.Bucket(s.bucket)
@@ -93,22 +93,22 @@ func (s PeerStorage) add(associated []string, value storage.Peer) (err error) {
 	err = s.bbolt.Batch(func(tx *bbolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists(s.bucket)
 		if err != nil {
-			return errors.Errorf("create bucket: %w", err)
+			return errors.Wrap(err, "create bucket")
 		}
 
 		data, err := json.Marshal(value)
 		if err != nil {
-			return errors.Errorf("marshal: %w", err)
+			return errors.Wrap(err, "marshal")
 		}
 		id := storage.KeyFromPeer(value).Bytes(nil)
 
 		if err := bucket.Put(id, data); err != nil {
-			return errors.Errorf("set id <-> data: %w", err)
+			return errors.Wrap(err, "set id <-> data")
 		}
 
 		for _, key := range associated {
 			if err := bucket.Put([]byte(key), id); err != nil {
-				return errors.Errorf("set key <-> id: %w", err)
+				return errors.Wrap(err, "set key <-> id")
 			}
 		}
 
@@ -139,7 +139,7 @@ func (s PeerStorage) Find(ctx context.Context, key storage.PeerKey) (p storage.P
 			if errors.Is(err, storage.ErrPeerUnmarshalMustInvalidate) {
 				return storage.ErrPeerNotFound
 			}
-			return errors.Errorf("unmarshal: %w", err)
+			return errors.Wrap(err, "unmarshal")
 		}
 		return nil
 	})
@@ -173,7 +173,7 @@ func (s PeerStorage) Resolve(ctx context.Context, key string) (p storage.Peer, r
 			if errors.Is(err, storage.ErrPeerUnmarshalMustInvalidate) {
 				return storage.ErrPeerNotFound
 			}
-			return errors.Errorf("unmarshal: %w", err)
+			return errors.Wrap(err, "unmarshal")
 		}
 		return nil
 	})

--- a/bbolt/session_example_test.go
+++ b/bbolt/session_example_test.go
@@ -17,7 +17,7 @@ import (
 func bboltStorage(ctx context.Context) error {
 	db, err := bboltdb.Open("bbolt.db", 0666, &bboltdb.Options{}) // nolint:gocritic
 	if err != nil {
-		return errors.Errorf("create bbolt storage: %w", err)
+		return errors.Wrap(err, "create bbolt storage")
 	}
 	storage := bbolt.NewSessionStorage(db, "session", []byte("bucket"))
 
@@ -25,7 +25,7 @@ func bboltStorage(ctx context.Context) error {
 		SessionStorage: storage,
 	})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/invoker/update.go
+++ b/invoker/update.go
@@ -24,7 +24,7 @@ func (h UpdateHook) Handle(next tg.Invoker) telegram.InvokeFunc {
 		}
 		if u, ok := output.(*tg.UpdatesBox); ok {
 			if err := h(ctx, u.Updates); err != nil {
-				return errors.Errorf("hook: %w", err)
+				return errors.Wrap(err, "hook")
 			}
 		}
 

--- a/middleware/floodwait/flood.go
+++ b/middleware/floodwait/flood.go
@@ -40,7 +40,7 @@ const (
 // perTypeWaitErrors is the set of code 420 errors that represent a per-method
 // rate limit: every request of the same type is throttled, so the waiter may
 // proactively delay future requests of that type.
-var perTypeWaitErrors = []string{
+var perTypeWaitErrors = []string{ // nolint:gochecknoglobals
 	errFloodWait,
 	errFloodPremiumWait,
 }
@@ -50,7 +50,7 @@ var perTypeWaitErrors = []string{
 // Telethon notes "SLOW_MODE_WAIT is chat-specific, not request-specific" and
 // does not cache these per CONSTRUCTOR_ID; we likewise retry only the offending
 // request without throttling unrelated calls of the same type.
-var localWaitErrors = []string{
+var localWaitErrors = []string{ // nolint:gochecknoglobals
 	errSlowmodeWait,
 	err2FAConfirmWait,
 	errTakeoutInitDelay,

--- a/middleware/floodwait/flood_test.go
+++ b/middleware/floodwait/flood_test.go
@@ -64,8 +64,10 @@ func TestAsWait(t *testing.T) {
 			wantOK:      true,
 		},
 		{
-			name:        "ClampHigh",
-			err:         tgerr.New(420, "FLOOD_WAIT_9999999999"),
+			name: "ClampHigh",
+			// Above maxWaitSeconds but within a 32-bit int so the argument
+			// parses on 386 as well as 64-bit platforms.
+			err:         tgerr.New(420, "FLOOD_WAIT_99999999"),
 			want:        maxFloodWait,
 			wantPerType: true,
 			wantOK:      true,

--- a/pebble/auth_example_test.go
+++ b/pebble/auth_example_test.go
@@ -21,7 +21,7 @@ import (
 func pebbleAuth(ctx context.Context) error {
 	db, err := pebbledb.Open("pebble.db", &pebbledb.Options{})
 	if err != nil {
-		return errors.Errorf("create pebble storage: %w", err)
+		return errors.Wrap(err, "create pebble storage")
 	}
 	cred := pebble.NewCredentials(db).
 		WithPhoneKey("phone").
@@ -29,7 +29,7 @@ func pebbleAuth(ctx context.Context) error {
 
 	client, err := telegram.ClientFromEnvironment(telegram.Options{})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/pebble/peer_storage.go
+++ b/pebble/peer_storage.go
@@ -54,7 +54,7 @@ func (p *pebbleIterator) Next(ctx context.Context) bool {
 	}
 
 	if err := json.Unmarshal(p.iter.Value(), &p.value); err != nil {
-		p.lastErr = errors.Errorf("unmarshal: %w", err)
+		p.lastErr = errors.Wrap(err, "unmarshal")
 		return false
 	}
 
@@ -95,7 +95,7 @@ func (s PeerStorage) Iterate(ctx context.Context) (storage.PeerIterator, error) 
 	iter, err := snap.NewIter(prefixIterOptions(storage.PeerKeyPrefix))
 	if err != nil {
 		_ = snap.Close()
-		return nil, errors.Errorf("new iter: %w", err)
+		return nil, errors.Wrap(err, "new iter")
 	}
 	iter.First()
 
@@ -108,7 +108,7 @@ func (s PeerStorage) Iterate(ctx context.Context) (storage.PeerIterator, error) 
 func (s PeerStorage) add(associated []string, value storage.Peer) (rerr error) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		return errors.Errorf("marshal: %w", err)
+		return errors.Wrap(err, "marshal")
 	}
 	id := storage.KeyFromPeer(value).Bytes(nil)
 
@@ -130,7 +130,7 @@ func (s PeerStorage) add(associated []string, value storage.Peer) (rerr error) {
 	}
 
 	if err := b.Commit(nil); err != nil {
-		return errors.Errorf("commit: %w", err)
+		return errors.Wrap(err, "commit")
 	}
 
 	return nil
@@ -150,7 +150,7 @@ func (s PeerStorage) Find(ctx context.Context, key storage.PeerKey) (_ storage.P
 		if errors.Is(err, pebble.ErrNotFound) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("get %q: %w", id, err)
+		return storage.Peer{}, errors.Wrapf(err, "get %q", id)
 	}
 	defer func() {
 		multierr.AppendInto(&rerr, closer.Close())
@@ -161,7 +161,7 @@ func (s PeerStorage) Find(ctx context.Context, key storage.PeerKey) (_ storage.P
 		if errors.Is(err, storage.ErrPeerUnmarshalMustInvalidate) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("unmarshal: %w", err)
+		return storage.Peer{}, errors.Wrap(err, "unmarshal")
 	}
 
 	return b, nil
@@ -186,7 +186,7 @@ func (s PeerStorage) Resolve(ctx context.Context, key string) (_ storage.Peer, r
 		if errors.Is(err, pebble.ErrNotFound) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("get %q: %w", key, err)
+		return storage.Peer{}, errors.Wrapf(err, "get %q", key)
 	}
 	defer func() {
 		multierr.AppendInto(&rerr, idCloser.Close())
@@ -198,7 +198,7 @@ func (s PeerStorage) Resolve(ctx context.Context, key string) (_ storage.Peer, r
 		if errors.Is(err, pebble.ErrNotFound) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("get %q: %w", id, err)
+		return storage.Peer{}, errors.Wrapf(err, "get %q", id)
 	}
 	defer func() {
 		multierr.AppendInto(&rerr, dataCloser.Close())
@@ -209,7 +209,7 @@ func (s PeerStorage) Resolve(ctx context.Context, key string) (_ storage.Peer, r
 		if errors.Is(err, storage.ErrPeerUnmarshalMustInvalidate) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("unmarshal: %w", err)
+		return storage.Peer{}, errors.Wrap(err, "unmarshal")
 	}
 
 	return b, nil

--- a/pebble/session_example_test.go
+++ b/pebble/session_example_test.go
@@ -17,7 +17,7 @@ import (
 func pebbleStorage(ctx context.Context) error {
 	db, err := pebbledb.Open("pebble.db", &pebbledb.Options{})
 	if err != nil {
-		return errors.Errorf("create pebble storage: %w", err)
+		return errors.Wrap(err, "create pebble storage")
 	}
 	storage := pebble.NewSessionStorage(db, "session")
 
@@ -25,7 +25,7 @@ func pebbleStorage(ctx context.Context) error {
 		SessionStorage: storage,
 	})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/redis/auth_example_test.go
+++ b/redis/auth_example_test.go
@@ -26,7 +26,7 @@ func redisAuth(ctx context.Context) error {
 
 	client, err := telegram.ClientFromEnvironment(telegram.Options{})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/redis/peer_storage.go
+++ b/redis/peer_storage.go
@@ -43,13 +43,13 @@ func (p *redisIterator) Next(ctx context.Context) bool {
 	key := p.iter.Val()
 	value, err := p.client.Get(ctx, key).Result()
 	if err != nil {
-		p.lastErr = errors.Errorf("get %q: %w", key, err)
+		p.lastErr = errors.Wrapf(err, "get %q", key)
 		return false
 	}
 
 	r := strings.NewReader(value)
 	if err := json.NewDecoder(r).Decode(&p.value); err != nil {
-		p.lastErr = errors.Errorf("unmarshal: %w", err)
+		p.lastErr = errors.Wrap(err, "unmarshal")
 		return false
 	}
 
@@ -81,13 +81,13 @@ func (s PeerStorage) Iterate(ctx context.Context) (storage.PeerIterator, error) 
 func (s PeerStorage) add(ctx context.Context, associated []string, value storage.Peer) (rerr error) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		return errors.Errorf("marshal: %w", err)
+		return errors.Wrap(err, "marshal")
 	}
 	id := storage.KeyFromPeer(value).String()
 
 	if len(associated) == 0 {
 		if err := s.redis.Set(ctx, id, data, 0).Err(); err != nil {
-			return errors.Errorf("set id <-> data: %w", err)
+			return errors.Wrap(err, "set id <-> data")
 		}
 
 		return nil
@@ -99,17 +99,17 @@ func (s PeerStorage) add(ctx context.Context, associated []string, value storage
 	}()
 
 	if err := tx.Set(ctx, id, data, 0).Err(); err != nil {
-		return errors.Errorf("set id <-> data: %w", err)
+		return errors.Wrap(err, "set id <-> data")
 	}
 
 	for _, key := range associated {
 		if err := tx.Set(ctx, key, id, 0).Err(); err != nil {
-			return errors.Errorf("set key <-> id: %w", err)
+			return errors.Wrap(err, "set key <-> id")
 		}
 	}
 
 	if _, err := tx.Exec(ctx); err != nil {
-		return errors.Errorf("exec: %w", err)
+		return errors.Wrap(err, "exec")
 	}
 
 	return nil
@@ -129,12 +129,12 @@ func (s PeerStorage) Find(ctx context.Context, key storage.PeerKey) (storage.Pee
 		if errors.Is(err, redis.Nil) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("get %q: %w", key, err)
+		return storage.Peer{}, errors.Wrapf(err, "get %q", key)
 	}
 
 	var b storage.Peer
 	if err := json.Unmarshal(data, &b); err != nil {
-		return storage.Peer{}, errors.Errorf("unmarshal: %w", err)
+		return storage.Peer{}, errors.Wrap(err, "unmarshal")
 	}
 
 	return b, nil
@@ -153,7 +153,7 @@ func (s PeerStorage) Resolve(ctx context.Context, key string) (storage.Peer, err
 		if errors.Is(err, redis.Nil) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("get %q: %w", key, err)
+		return storage.Peer{}, errors.Wrapf(err, "get %q", key)
 	}
 
 	// Find object by id.
@@ -162,12 +162,12 @@ func (s PeerStorage) Resolve(ctx context.Context, key string) (storage.Peer, err
 		if errors.Is(err, redis.Nil) {
 			return storage.Peer{}, storage.ErrPeerNotFound
 		}
-		return storage.Peer{}, errors.Errorf("get %q: %w", id, err)
+		return storage.Peer{}, errors.Wrapf(err, "get %q", id)
 	}
 
 	var b storage.Peer
 	if err := json.Unmarshal(data, &b); err != nil {
-		return storage.Peer{}, errors.Errorf("unmarshal: %w", err)
+		return storage.Peer{}, errors.Wrap(err, "unmarshal")
 	}
 
 	return b, nil

--- a/redis/session_example_test.go
+++ b/redis/session_example_test.go
@@ -22,14 +22,14 @@ func redisStorage(ctx context.Context) error {
 		SessionStorage: storage,
 	})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {
 		// Force redis to flush DB.
 		// It may be necessary to be sure that session will be saved to the disk.
 		if err := redisClient.FlushDBAsync(ctx).Err(); err != nil {
-			return errors.Errorf("flush: %w", err)
+			return errors.Wrap(err, "flush")
 		}
 
 		_, err := client.Auth().Bot(ctx, os.Getenv("BOT_TOKEN"))

--- a/s3/session.go
+++ b/s3/session.go
@@ -32,7 +32,7 @@ func NewSessionStorage(client *minio.Client, bucketName, objectName string) Sess
 func (s SessionStorage) LoadSession(ctx context.Context) ([]byte, error) {
 	obj, err := s.client.GetObject(ctx, s.bucketName, s.objectName, minio.GetObjectOptions{})
 	if err != nil {
-		return nil, errors.Errorf("get %q/%q: %w", s.bucketName, s.objectName, err)
+		return nil, errors.Wrapf(err, "get %q/%q", s.bucketName, s.objectName)
 	}
 	return io.ReadAll(obj)
 }
@@ -40,7 +40,7 @@ func (s SessionStorage) LoadSession(ctx context.Context) ([]byte, error) {
 // StoreSession implements session.Storage.
 func (s SessionStorage) StoreSession(ctx context.Context, data []byte) error {
 	if err := s.client.MakeBucket(ctx, s.bucketName, minio.MakeBucketOptions{}); err != nil {
-		return errors.Errorf("create bucket %q: %w", s.bucketName, err)
+		return errors.Wrapf(err, "create bucket %q", s.bucketName)
 	}
 
 	_, err := s.client.PutObject(ctx, s.bucketName, s.objectName,
@@ -51,7 +51,7 @@ func (s SessionStorage) StoreSession(ctx context.Context, data []byte) error {
 		},
 	)
 	if err != nil {
-		return errors.Errorf("put %q/%q: %w", s.bucketName, s.objectName, err)
+		return errors.Wrapf(err, "put %q/%q", s.bucketName, s.objectName)
 	}
 
 	return nil

--- a/s3/session_example_test.go
+++ b/s3/session_example_test.go
@@ -23,7 +23,7 @@ func s3Storage(ctx context.Context) error {
 		Creds: credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
 	})
 	if err != nil {
-		return errors.Errorf("create s3 storage: %w", err)
+		return errors.Wrap(err, "create s3 storage")
 	}
 	storage := s3.NewSessionStorage(db, "telegram", "session")
 
@@ -31,7 +31,7 @@ func s3Storage(ctx context.Context) error {
 		SessionStorage: storage,
 	})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/storage/collector.go
+++ b/storage/collector.go
@@ -41,7 +41,7 @@ func (c PeerCollector) Dialogs(ctx context.Context, iter *dialogs.Iterator) erro
 		}
 
 		if err := c.storage.Add(ctx, p); err != nil {
-			return errors.Errorf("add: %w", err)
+			return errors.Wrap(err, "add")
 		}
 	}
 
@@ -64,7 +64,7 @@ func (c PeerCollector) Participants(ctx context.Context, iter *participants.Iter
 			continue
 		}
 		if err := c.storage.Add(ctx, p); err != nil {
-			return errors.Errorf("add: %w", err)
+			return errors.Wrap(err, "add")
 		}
 	}
 
@@ -79,7 +79,7 @@ func (c PeerCollector) Contacts(ctx context.Context, contacts *tg.ContactsContac
 			continue
 		}
 		if err := c.storage.Add(ctx, p); err != nil {
-			return errors.Errorf("add: %w", err)
+			return errors.Wrap(err, "add")
 		}
 	}
 	return nil

--- a/storage/collector_example_test.go
+++ b/storage/collector_example_test.go
@@ -20,14 +20,14 @@ import (
 func peerCollector(ctx context.Context) error {
 	db, err := pebbledb.Open("pebble.db", &pebbledb.Options{})
 	if err != nil {
-		return errors.Errorf("create pebble storage: %w", err)
+		return errors.Wrap(err, "create pebble storage")
 	}
 	s := pebble.NewPeerStorage(db)
 	collector := storage.CollectPeers(s)
 
 	client, err := telegram.ClientFromEnvironment(telegram.Options{})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 	raw := tg.NewClient(client)
 

--- a/storage/find.go
+++ b/storage/find.go
@@ -27,7 +27,7 @@ func FindPeer(ctx context.Context, s PeerStorage, p tg.PeerClass) (Peer, error) 
 func ForEach(ctx context.Context, iterator PeerIterator, cb func(Peer) error) error {
 	for iterator.Next(ctx) {
 		if err := cb(iterator.Value()); err != nil {
-			return errors.Errorf("callback: %w", err)
+			return errors.Wrap(err, "callback")
 		}
 	}
 	return iterator.Err()

--- a/storage/hook_example_test.go
+++ b/storage/hook_example_test.go
@@ -20,7 +20,7 @@ import (
 func updatesHook(ctx context.Context) error {
 	db, err := pebbledb.Open("pebble.db", &pebbledb.Options{})
 	if err != nil {
-		return errors.Errorf("create pebble storage: %w", err)
+		return errors.Wrap(err, "create pebble storage")
 	}
 	s := pebble.NewPeerStorage(db)
 
@@ -30,7 +30,7 @@ func updatesHook(ctx context.Context) error {
 		UpdateHandler: handler,
 	})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 	raw := tg.NewClient(client)
 	sender := message.NewSender(raw)

--- a/storage/key.go
+++ b/storage/key.go
@@ -69,7 +69,7 @@ func (k *PeerKey) Parse(r []byte) error {
 	{
 		v, err := strconv.Atoi(string(r[:idx]))
 		if err != nil {
-			return errors.Errorf("parse kind: %w", err)
+			return errors.Wrap(err, "parse kind")
 		}
 		if v > int(dialogs.Channel) {
 			return errors.Errorf("invalid kind %d", v)
@@ -80,7 +80,7 @@ func (k *PeerKey) Parse(r []byte) error {
 	{
 		v, err := strconv.ParseInt(string(r[idx+1:]), 10, 64)
 		if err != nil {
-			return errors.Errorf("parse id: %w", err)
+			return errors.Wrap(err, "parse id")
 		}
 		k.ID = v
 	}

--- a/storage/peer.go
+++ b/storage/peer.go
@@ -310,7 +310,7 @@ func (p *Peer) Keys() []string {
 func (p *Peer) FromInputPeer(input tg.InputPeerClass) error {
 	k := dialogs.DialogKey{}
 	if err := k.FromInputPeer(input); err != nil {
-		return errors.Errorf("unpack input peer: %w", err)
+		return errors.Wrap(err, "unpack input peer")
 	}
 
 	*p = Peer{

--- a/storage/resolver_cache.go
+++ b/storage/resolver_cache.go
@@ -33,11 +33,11 @@ func (r ResolverCache) notFound(
 
 	var value Peer
 	if err := value.FromInputPeer(resolved); err != nil {
-		return nil, errors.Errorf("extract object: %w", err)
+		return nil, errors.Wrap(err, "extract object")
 	}
 
 	if err := r.storage.Assign(ctx, key, value); err != nil {
-		return nil, errors.Errorf("assign %q: %w", key, err)
+		return nil, errors.Wrapf(err, "assign %q", key)
 	}
 
 	return resolved, nil
@@ -53,7 +53,7 @@ func (r ResolverCache) tryResolve(
 		if errors.Is(err, ErrPeerNotFound) {
 			return r.notFound(ctx, key, f)
 		}
-		return nil, errors.Errorf("get %q: %w", key, err)
+		return nil, errors.Wrapf(err, "get %q", key)
 	}
 	return b.AsInputPeer(), nil
 }

--- a/storage/resolver_cache_example_test.go
+++ b/storage/resolver_cache_example_test.go
@@ -22,12 +22,12 @@ import (
 func resolverCache(ctx context.Context) error {
 	db, err := pebbledb.Open("pebble.db", &pebbledb.Options{})
 	if err != nil {
-		return errors.Errorf("create pebble storage: %w", err)
+		return errors.Wrap(err, "create pebble storage")
 	}
 
 	client, err := telegram.ClientFromEnvironment(telegram.Options{})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/tg_io/download_test.go
+++ b/tg_io/download_test.go
@@ -70,12 +70,12 @@ func TestE2E(t *testing.T) {
 		const size = chunk1kb*5 + 100
 		f, err := uploader.NewUploader(api).FromBytes(ctx, "upload.bin", make([]byte, size))
 		if err != nil {
-			return errors.Errorf("upload: %w", err)
+			return errors.Wrap(err, "upload")
 		}
 
 		mc, err := message.NewSender(api).Self().UploadMedia(ctx, message.File(f))
 		if err != nil {
-			return errors.Errorf("create media: %w", err)
+			return errors.Wrap(err, "create media")
 		}
 
 		media, ok := mc.(*tg.MessageMediaDocument)
@@ -94,7 +94,7 @@ func TestE2E(t *testing.T) {
 
 		const offset = chunk1kb / 2
 		if err := u.StreamAt(ctx, offset, buf); err != nil {
-			return errors.Errorf("stream at %d: %w", offset, err)
+			return errors.Wrapf(err, "stream at %d", offset)
 		}
 
 		t.Log(buf.Len())
@@ -102,7 +102,7 @@ func TestE2E(t *testing.T) {
 
 		ln, err := net.Listen("tcp", "localhost:0")
 		if err != nil {
-			return errors.Errorf("listen: %w", err)
+			return errors.Wrap(err, "listen")
 		}
 		defer func() {
 			_ = ln.Close()
@@ -123,7 +123,7 @@ func TestE2E(t *testing.T) {
 		})
 		g.Go(func() error {
 			if err := s.Serve(ln); err != nil && err != http.ErrServerClosed {
-				return errors.Errorf("server: %w", err)
+				return errors.Wrap(err, "server")
 			}
 			return nil
 		})
@@ -142,14 +142,14 @@ func TestE2E(t *testing.T) {
 
 			res, err := http.DefaultClient.Do(req)
 			if err != nil {
-				return errors.Errorf("send GET %q: %w", requestURL, err)
+				return errors.Wrapf(err, "send GET %q", requestURL)
 			}
 			defer func() { _ = res.Body.Close() }()
 			t.Log(res.Status)
 
 			outBuf := new(bytes.Buffer)
 			if _, err := io.Copy(outBuf, res.Body); err != nil {
-				return errors.Errorf("read response: %w", err)
+				return errors.Wrap(err, "read response")
 			}
 
 			t.Log(outBuf.Len())

--- a/vault/auth_example_test.go
+++ b/vault/auth_example_test.go
@@ -20,7 +20,7 @@ import (
 func vaultAuth(ctx context.Context) error {
 	vaultClient, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
-		return errors.Errorf("create Vault client: %w", err)
+		return errors.Wrap(err, "create Vault client")
 	}
 	cred := vault.NewCredentials(vaultClient, "cubbyhole/telegram/user").
 		WithPhoneKey("phone").
@@ -28,7 +28,7 @@ func vaultAuth(ctx context.Context) error {
 
 	client, err := telegram.ClientFromEnvironment(telegram.Options{})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {

--- a/vault/client.go
+++ b/vault/client.go
@@ -33,7 +33,7 @@ func (c vaultClient) putAll(ctx context.Context, data map[string]interface{}) er
 
 	err := req.SetJSONBody(data)
 	if err != nil {
-		return errors.Errorf("request encode: %w", err)
+		return errors.Wrap(err, "request encode")
 	}
 
 	resp, err := c.client.RawRequestWithContext(ctx, req)
@@ -43,7 +43,7 @@ func (c vaultClient) putAll(ctx context.Context, data map[string]interface{}) er
 		}()
 	}
 	if err != nil {
-		return errors.Errorf("secret send: %w", err)
+		return errors.Wrap(err, "secret send")
 	}
 
 	return nil
@@ -77,12 +77,12 @@ func (c vaultClient) getAll(ctx context.Context) (*api.Secret, error) {
 		}
 	}
 	if err != nil {
-		return nil, errors.Errorf("secret fetch: %w", err)
+		return nil, errors.Wrap(err, "secret fetch")
 	}
 
 	secret, err := api.ParseSecret(resp.Body)
 	if err != nil {
-		return nil, errors.Errorf("secret parsing: %w", err)
+		return nil, errors.Wrap(err, "secret parsing")
 	}
 
 	return secret, nil

--- a/vault/session_example_test.go
+++ b/vault/session_example_test.go
@@ -17,7 +17,7 @@ import (
 func vaultStorage(ctx context.Context) error {
 	vaultClient, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
-		return errors.Errorf("create Vault client: %w", err)
+		return errors.Wrap(err, "create Vault client")
 	}
 	storage := vault.NewSessionStorage(vaultClient, "cubbyhole/telegram/user", "session")
 
@@ -25,7 +25,7 @@ func vaultStorage(ctx context.Context) error {
 		SessionStorage: storage,
 	})
 	if err != nil {
-		return errors.Errorf("create client: %w", err)
+		return errors.Wrap(err, "create client")
 	}
 
 	return client.Run(ctx, func(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- Replace `errors.Errorf` with a `%w` directive by `errors.Wrap`/`errors.Wrapf` across the codebase. `go-faster/errors.Errorf` does handle `%w` at runtime (it delegates to `fmt.Errorf`), but `govet`'s printf analyzer doesn't recognize it as `%w`-supporting and flags every usage. This matches the maintainer's recent direction (0ae340b).
- Mark the floodwait error-set slices (`perTypeWaitErrors`, `localWaitErrors`) with `// nolint:gochecknoglobals`, consistent with the existing pattern in `storage/key.go`.
- Fix the `arch: 386` CI failure: `TestAsWait/ClampHigh` used `FLOOD_WAIT_9999999999`, whose argument overflows a 32-bit `int`, so `tgerr` couldn't strip the trailing number and the type match failed. Switched to `FLOOD_WAIT_99999999` — still above `maxWaitSeconds` so it exercises the upper clamp, but within a 32-bit int.

## Test plan

- `golangci-lint run ./...` → 0 issues
- `go test ./...` passes
- `GOARCH=386 go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)