### PR TITLE
ci: pin Go to 1.25.x across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         flags: [""]
         go:
-          - 1.24.x
+          - 1.25.x
         arch:
           - amd64
         runner:
@@ -24,16 +24,16 @@ jobs:
           - macos-latest
         include:
           - arch: 386
-            go: 1.24.x
+            go: 1.25.x
             runner: ubuntu-latest
 
           - arch: amd64
             runner: windows-latest
-            go: 1.24.x
+            go: 1.25.x
             flags: "-p=1"
 
           - arch: amd64
-            go: 1.24.x
+            go: 1.25.x
             runner: ubuntu-latest
             flags: "-race"
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment
@@ -101,7 +101,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Lint
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment
@@ -71,7 +71,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
 
       - name: Get Go environment


### PR DESCRIPTION
## Summary

The golang group bump (#733) raised `go.mod`'s directive to `go 1.25.0`, because `golang.org/x/{sync,term,text,time}` now require Go 1.25. However the CI workflows still pin older Go:

- `ci.yml` (test matrix) and `coverage.yml`: `1.24.x`
- `lint.yml` (golangci-lint, check-mod, check-generate) and `e2e.yml` (vault, redis, s3, tg_io): `1.21.x`

These only build because `actions/setup-go@v5` auto-downloads the 1.25 toolchain on demand. That has two problems:

1. The coverage job fails with `go: no such tool "covdata"` because of the toolchain switch.
2. `actions/setup-go@v6` (#716) sets `GOTOOLCHAIN=local`, disabling the auto-download, so every job would fail with `go.mod requires go >= 1.25.0`.

This pins every job to `1.25.x` to match `go.mod`, fixing the coverage job and unblocking the setup-go v6 bump.

## Test plan

- All CI jobs (test matrix, coverage, lint, e2e) run on Go 1.25.x and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)